### PR TITLE
fix: remove EnableSampling() that causes 30s error log spam

### DIFF
--- a/main.go
+++ b/main.go
@@ -435,9 +435,6 @@ func main() {
 		server.WithRecovery(),
 	)
 
-	// Declare sampling capability (optional, harmless if unused)
-	s.EnableSampling()
-
 	// ─── MCP Resources ─────────────────────────────────────────────────
 	// Resources allow AI clients to passively load memory context without
 	// explicitly calling tools, improving memory awareness and utilization.


### PR DESCRIPTION
## Summary

- Removes `s.EnableSampling()` and its misleading comment from `main.go`
- The server declared sampling capability but never used it — no tool handler calls `RequestSampling`
- This caused mcp-go to misroute heartbeat ping responses through the sampling handler, logging errors every 30 seconds

Closes #1

## Test plan

- [x] `make check` passes
- [x] `go test ./...` passes
- [x] `make build` produces binary
- [x] No remaining `EnableSampling`/`RequestSampling` references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)